### PR TITLE
feat: ナビゲーションのコミュニティに処罰一覧を追加

### DIFF
--- a/components/TheHeader.vue
+++ b/components/TheHeader.vue
@@ -141,6 +141,11 @@ export default {
               href: 'https://map.jaoafa.com/',
               value: 'server-dynmap',
             },
+            {
+              text: '処罰一覧',
+              href: 'https://bans.jaoafa.com',
+              value: 'community-bans',
+            },
           ],
         },
         {
@@ -156,11 +161,6 @@ export default {
               text: 'ユーザ一覧',
               href: 'https://users.jaoafa.com',
               value: 'community-users',
-            },
-            {
-              text: '処罰一覧',
-              href: 'https://bans.jaoafa.com',
-              value: 'community-bans',
             },
             {
               text: 'Wiki',

--- a/components/TheHeader.vue
+++ b/components/TheHeader.vue
@@ -158,6 +158,11 @@ export default {
               value: 'community-users',
             },
             {
+              text: '処罰一覧',
+              href: 'https://bans.jaoafa.com',
+              value: 'community-bans',
+            },
+            {
               text: 'Wiki',
               href: 'https://wiki.jaoafa.com',
               value: 'community-wiki',


### PR DESCRIPTION
各ページの上部に表示されるナビゲーションの「コミュニティ」に bans.jaoafa.com へのリンク「処罰一覧」を追加しました。