### PR TITLE
fix(desktop-header): #2 PC版グローバルナビゲーションボタン押下後に閉じる

### DIFF
--- a/components/TheHeader.vue
+++ b/components/TheHeader.vue
@@ -38,7 +38,10 @@
       :current="navigationCurrent"
       :items="navigationItems"
       :mobile-state="navigationMobileState"
-      @close="navigationMobileState = false"
+      @close="
+        navigationMobileState = false
+        navigationCurrent = ''
+      "
     />
   </header>
 </template>

--- a/components/TheHeaderExpanded.vue
+++ b/components/TheHeaderExpanded.vue
@@ -4,7 +4,7 @@
     :class="{ show: mobileState, selected: current }"
   >
     <the-header-expanded-mobile :items="items" @close="closeNavigation" />
-    <the-header-expanded-desktop :current="current" :items="items" />
+    <the-header-expanded-desktop :current="current" :items="items" @close="closeNavigation" />
   </div>
 </template>
 

--- a/components/TheHeaderExpandedDesktop.vue
+++ b/components/TheHeaderExpandedDesktop.vue
@@ -20,6 +20,7 @@
           v-if="item.to"
           :to="item.to"
           class="the-header-expanded-desktop__link"
+          @click.native="closeNavigation"
         >
           {{ item.text }}
         </nuxt-link>
@@ -41,6 +42,7 @@
               v-if="page.to"
               :to="page.to"
               class="the-header-expanded-desktop__link"
+              @click.native="closeNavigation"
             >
               {{ page.text }}
             </nuxt-link>
@@ -96,6 +98,11 @@ export default {
           this.currentIndex = newValue
         }
       },
+    },
+  },
+  methods: {
+    closeNavigation() {
+      this.$emit('close')
     },
   },
 }


### PR DESCRIPTION
close #2 

PC版（デスクトップ版）において、グローバルナビゲーションにある内部リンクボタンを押した際にグローバルナビゲーションが閉じるように変更しました。

![20211226-075927-H44LT9ygbo](https://user-images.githubusercontent.com/8929706/147395102-f364dc11-193f-4f9b-8654-8ef7c1d45350.gif)
