### PR TITLE
fix(mobile-header): #9 グローバルナビゲーション第1階層押下時に閉じるように

### DIFF
--- a/components/TheHeaderExpandedMobile.vue
+++ b/components/TheHeaderExpandedMobile.vue
@@ -11,6 +11,7 @@
           v-if="category.to"
           :to="category.to"
           class="the-header-expanded-mobile__link"
+          @click.native="closeNavigation"
         >
           <span class="the-header-expanded-mobile__label">
             {{ category.text }}


### PR DESCRIPTION
close #9 

モバイル版のときにグローバルナビゲーションの第一階層にある項目をタップするとグローバルナビゲーションが閉じるように変更しました。

![20211226-082845-uRnnOavF3A](https://user-images.githubusercontent.com/8929706/147395457-3cb14ee5-cbe0-4916-841c-d90ee776dad4.gif)

(すみません間違えてmasterで作業してプッシュしたのでrevertしました)