### PR TITLE
fix(toc): #103 見出しがない場合は目次を表示しないように

### DIFF
--- a/components/ArticleToc.vue
+++ b/components/ArticleToc.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="article-toc">
+  <div v-if="article.toc.length !== 0" class="article-toc">
     <header class="article-toc__header" @click="toggleState">
       <span>目次</span>
       <app-icon

--- a/content/server/index.md
+++ b/content/server/index.md
@@ -6,8 +6,6 @@ updatedAt: 2021-03-14
 
 ここではサーバのあんな情報やこんな情報を掲示しています。
 
-## ページ一覧
-
 - [はじめての方へ](/server/beginners)
 - [運営者情報](/server/profiles)
 - [サービス仕様](/server/specifications)


### PR DESCRIPTION
close #103 

ページ内に見出しが存在しない場合は目次を表示しないように変更しました。

![20211226-083959-VZ4MnBZknd](https://user-images.githubusercontent.com/8929706/147395554-a5c82f08-9668-49ef-9bd9-eddd5eee15bc.gif)
