### PR TITLE
fix: マージされたときのみリリース処理を実施

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
マージされなくてもプルリクがクローズされたらリリース処理がおこなわれるようになっていたので、これを修正。

https://github.com/jaoafa/jaoweb/pull/147
https://github.com/jaoafa/jaoweb/actions/runs/1676614223