### PR TITLE
feat: ナビゲーションにステータスページを追加

### DIFF
--- a/components/TheHeader.vue
+++ b/components/TheHeader.vue
@@ -182,6 +182,11 @@ export default {
           value: 'support',
           children: [
             {
+              text: 'ステータスページ',
+              href: 'https://status.jaoafa.com',
+              value: 'support-status',
+            },
+            {
               text: 'お問い合わせ',
               to: '/support/inquiry',
               value: 'support-inquiry',


### PR DESCRIPTION
表題の通りです。

ナビゲーションバーの「サポート」の下に「ステータスページ」を追加しました。