### PR TITLE
feat: データサイトのリンクを追加

### DIFF
--- a/components/TheHeader.vue
+++ b/components/TheHeader.vue
@@ -161,8 +161,13 @@ export default {
           value: 'community',
           children: [
             {
-              text: 'ユーザ一覧',
+              text: 'ユーザページ',
               href: 'https://users.jaoafa.com',
+              value: 'community-users',
+            },
+            {
+              text: 'データサイト',
+              href: 'https://jaoafa.com/data/',
               value: 'community-users',
             },
             {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8929706/175821556-127eeb3c-29aa-4049-86c4-72f42aef6aa5.png)

- データサイト (jao Minecraft Data) `jaoafa.com/data/` へのリンクを追加
- もともと「ユーザ一覧」としていた `users.jaoafa.com` へのリンク名を「ユーザページ」に変更 (伸ばし棒と漢字「一」が分かりにくいなあと思ったので)

「データサイト」という名称に関しては議論の余地がある気がするので、もしほかの名前案があればください