### PR TITLE
ci: `set-output` 無効化に伴うCIの修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           check-latest: true
       - name: Get yarn cache directory path 🛠
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Cache node_modules 📦
         uses: actions/cache@v2
         id: yarn-cache


### PR DESCRIPTION
2023年6月以降、`set-output` 構文が無効化されます。本PRはこれの修正です。

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/